### PR TITLE
patch: support token besides legacy api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ homeassistant:
 http:
   api_password: passwd
 ```
+## 高于0.90请修改为
+```
+homeassistant:
+  auth_providers:
+   - type: legacy_api_password
+     api_password: passwd
+
+```
 
 ## 使用帮助
 - 绑定插件.

--- a/lib/Homeassistant.js
+++ b/lib/Homeassistant.js
@@ -21,6 +21,7 @@ function _request(method, path, body) {
 
     if (apiConfig.password) {
       options.headers['x-ha-access'] = apiConfig.password;
+      options.headers['Authorization'] = 'Bearer '+apiConfig.password;
     }
 
     if (method !== 'GET' && typeof body !== 'undefined') {


### PR DESCRIPTION
以兼容的形式增加了token方式的验证，防止legacy-api不能用

我不知道Rokid官方是怎么收录的，pull给你，请升级一下~ 